### PR TITLE
Fix Frontend API Integration - Remove Template Responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Frontend Environment Variables for Vercel Deployment
+
+# Backend API URL (HuggingFace Space)
+NEXT_PUBLIC_API_BASE_URL=https://minatoz997-backend66.hf.space
+
+# WebSocket URL (if needed)
+NEXT_PUBLIC_WS_URL=wss://minatoz997-backend66.hf.space
+
+# Optional: OpenRouter API Key (if frontend needs direct access)
+# NEXT_PUBLIC_OPENROUTER_API_KEY=your_openrouter_api_key_here

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -81,21 +81,41 @@ export function ChatInterface() {
         setConversation(newConversation)
       }
 
-      // Simulate AI response (replace with actual WebSocket connection)
-      setTimeout(() => {
+      // Send message to backend API
+      try {
+        const chatResponse = await apiService.sendChatMessage({
+          message: userMessage.content,
+          conversation_id: conversation?.id,
+          model: 'anthropic/claude-3.5-sonnet',
+          max_tokens: 2000,
+          temperature: 0.7
+        })
+
         const aiMessage: Message = {
           id: generateId(),
           role: 'assistant',
-          content: `I understand you want me to help with: "${userMessage.content}"\n\nI'm a powerful AI agent that can execute code, browse the web, and interact with various tools. Let me help you with that!\n\nFor example, if you need me to:\n- Write and execute code\n- Browse websites for information\n- Manage files and directories\n- Perform data analysis\n- Automate tasks\n\nJust let me know what specific task you'd like me to help with, and I'll get started right away!`,
+          content: chatResponse.response || chatResponse.message || 'Sorry, I received an empty response.',
           timestamp: new Date(),
           type: 'text'
         }
         setMessages(prev => [...prev, aiMessage])
         setIsLoading(false)
-      }, 2000)
+      } catch (apiError) {
+        console.error('API Error:', apiError)
+        // Fallback to a more helpful error message
+        const errorMessage: Message = {
+          id: generateId(),
+          role: 'assistant',
+          content: 'I apologize, but I\'m having trouble connecting to my backend services right now. Please check if the backend is running and try again.',
+          timestamp: new Date(),
+          type: 'error'
+        }
+        setMessages(prev => [...prev, errorMessage])
+        setIsLoading(false)
+      }
 
     } catch (error) {
-      console.error('Error sending message:', error)
+      console.error('Error in conversation flow:', error)
       const errorMessage: Message = {
         id: generateId(),
         role: 'assistant',

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -109,6 +109,26 @@ export const apiService = {
     const response = await api.delete(url)
     return response.data
   },
+
+  // Chat with OpenRouter API
+  async sendChatMessage(data: {
+    message: string
+    conversation_id?: string
+    model?: string
+    api_key?: string
+    stream?: boolean
+    max_tokens?: number
+    temperature?: number
+  }): Promise<any> {
+    const response = await api.post('/chat/message', data)
+    return response.data
+  },
+
+  // Get chat service info
+  async getChatInfo(): Promise<any> {
+    const response = await api.get('/chat/')
+    return response.data
+  },
 }
 
 export default api


### PR DESCRIPTION
## Problem Fixed

Frontend was showing hardcoded template responses instead of using the real backend API. The chat interface had a setTimeout simulation that returned template text.

## Changes Made

- Added sendChatMessage() function to properly call /chat/message endpoint
- Removed hardcoded setTimeout simulation
- Added real API integration with backend
- Uses anthropic/claude-3.5-sonnet model in API calls
- Added .env.example with proper backend URL configuration

## Deployment Notes

For Vercel deployment, ensure these environment variables are set:
- NEXT_PUBLIC_API_BASE_URL=https://minatoz997-backend66.hf.space
- NEXT_PUBLIC_WS_URL=wss://minatoz997-backend66.hf.space

This fixes the core issue where frontend was disconnected from backend services.

@LillyLove888 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e3ac0f4db0ea4c6a8eb5cb8cfc90ecdb)